### PR TITLE
remove description from config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,5 @@ category:
 tags:
 
 title:
-description:
 pages:
   - ["Documentation Title", "index"]


### PR DESCRIPTION
Description is no longer used by the Docs Site UI